### PR TITLE
Prevent duplicate tasks

### DIFF
--- a/data/tasks.txt
+++ b/data/tasks.txt
@@ -4,3 +4,9 @@
 [T][ ]buy apples
 [D][ ]buy oranges (by: tmr)
 [E][ ]buy pineapples (from: Feb 20 2003 to: 4/11/2005)
+[T][ ]readbook
+[D][ ]write book  (by: today)
+[T][ ]read       book
+[T][ ]read      book
+[T][ ]read     book
+[T][ ]read    book

--- a/src/main/java/tommy/Parser.java
+++ b/src/main/java/tommy/Parser.java
@@ -42,7 +42,7 @@ public class Parser {
         Command command;
 
         try {
-            String[] components = userInput.split(" ", 2);
+            String[] components = userInput.stripTrailing().split(" ", 2);
             String description;
             CommandType commandType = CommandType.valueOf(components[0].toUpperCase());
 

--- a/src/main/java/tommy/command/AddDeadlineCommand.java
+++ b/src/main/java/tommy/command/AddDeadlineCommand.java
@@ -14,7 +14,6 @@ import tommy.task.TaskList;
 public class AddDeadlineCommand extends Command {
     private String description;
 
-
     /**
      * Constructor for an AddDeadline command,
      * which initialises the command with its task description.
@@ -22,7 +21,7 @@ public class AddDeadlineCommand extends Command {
      * @param description Description of the Deadline task.
      */
     public AddDeadlineCommand(String description) {
-        this.description = description;
+        this.description = description.strip();
     }
 
     @Override
@@ -34,6 +33,11 @@ public class AddDeadlineCommand extends Command {
 
             String formattedByDate = Parser.formatDate(byDate);
             String formattedDescription = deadlineDetail + " (by: " + formattedByDate + ")";
+
+            boolean isDuplicate = taskList.isADuplicateTask(taskList, formattedDescription);
+            if (isDuplicate) {
+                throw new InvalidArgumentException("DEADLINE - There is already an identical task");
+            }
 
             Task deadline = new Deadline(formattedDescription);
 

--- a/src/main/java/tommy/command/AddEventCommand.java
+++ b/src/main/java/tommy/command/AddEventCommand.java
@@ -22,7 +22,7 @@ public class AddEventCommand extends Command {
      * @param description Description of the Event task.
      */
     public AddEventCommand(String description) {
-        this.description = description;
+        this.description = description.strip();
     }
 
     @Override
@@ -38,6 +38,11 @@ public class AddEventCommand extends Command {
 
             String formattedDescription = eventDetail
                     + " (from: " + formattedFromDate + " to: " + formattedToDate + ")";
+
+            boolean isDuplicate = taskList.isADuplicateTask(taskList, formattedDescription);
+            if (isDuplicate) {
+                throw new InvalidArgumentException("EVENT - There is already an identical task");
+            }
 
             Task event = new Event(formattedDescription);
 

--- a/src/main/java/tommy/command/AddTodoCommand.java
+++ b/src/main/java/tommy/command/AddTodoCommand.java
@@ -3,9 +3,7 @@ package tommy.command;
 import tommy.Storage;
 import tommy.Ui;
 import tommy.exception.InvalidArgumentException;
-import tommy.task.Task;
-import tommy.task.TaskList;
-import tommy.task.Todo;
+import tommy.task.*;
 
 /**
  * Represents the command to add a Todo task to the taskList.
@@ -19,14 +17,10 @@ public class AddTodoCommand extends Command {
      * which initialises the command with its task description.
      *
      * @param description Description of the Todo task.
-     * @throws InvalidArgumentException If the description is empty.
      */
 
-    public AddTodoCommand(String description) throws InvalidArgumentException {
-        if (description == null || description.trim().isBlank()) {
-            throw new InvalidArgumentException("TODO");
-        }
-        this.description = description;
+    public AddTodoCommand(String description) {
+        this.description = description.strip();
     }
 
     @Override
@@ -34,11 +28,18 @@ public class AddTodoCommand extends Command {
         try {
             Task todo = new Todo(this.description);
 
+            boolean isDuplicate = taskList.isADuplicateTask(taskList, this.description);
+            if (isDuplicate) {
+                throw new InvalidArgumentException("TODO - There is already an identical task");
+            }
+
             taskList.addTask(todo);
             Storage.save(taskList);
             return Ui.displayNewTask(todo, taskList);
+
         } catch (ArrayIndexOutOfBoundsException e) {
             throw new InvalidArgumentException("TODO");
         }
     }
+
 }

--- a/src/main/java/tommy/task/Deadline.java
+++ b/src/main/java/tommy/task/Deadline.java
@@ -4,6 +4,7 @@ package tommy.task;
  * Represents the task with a deadline in the format [ <code>details</code> (by: <code>date</code>) ].
  */
 public class Deadline extends Task {
+    private static final String symbol = "[D]";
 
     /**
      * Constructor for a Deadline task with its status as default not done.
@@ -27,7 +28,7 @@ public class Deadline extends Task {
 
     @Override
     public String toString() {
-        return "[D]" + this.getStatusIcon() + this.description;
+        return symbol + this.getStatusIcon() + this.description;
     }
 
 }

--- a/src/main/java/tommy/task/Event.java
+++ b/src/main/java/tommy/task/Event.java
@@ -4,6 +4,8 @@ package tommy.task;
  * Represents an Event task with the format [ details (from: <code>date</code>) to: <code>date</code>) ].
  */
 public class Event extends Task {
+    private static final String symbol = "[E]";
+
     /**
      * Constructor for an Event task with status as default not done.
      *
@@ -26,7 +28,7 @@ public class Event extends Task {
 
     @Override
     public String toString() {
-        return "[E]" + this.getStatusIcon() + this.description;
+        return symbol + this.getStatusIcon() + this.description;
     }
 }
 

--- a/src/main/java/tommy/task/TaskList.java
+++ b/src/main/java/tommy/task/TaskList.java
@@ -63,6 +63,21 @@ public class TaskList {
     }
 
     /**
+     * Returns the description of task in the taskList at the position specified, without task symbol
+     * and status symbol.
+     *
+     * @param position Position of task in the taskList to be retrieved.
+     * @return Description of task at specified position without task or status symbol.
+     */
+    public String getTaskDescAtPosition(int position) {
+        Task task = getTaskAtPosition(position);
+        String[] components = task.toString().split("\\[\\s\\]|\\[X\\]");
+        String description = components[1];
+
+        return description;
+    }
+
+    /**
      * Marks the task in the specified position in the taskList as done.
      *
      * @param position Position of task in the taskList to be marked as done.
@@ -89,5 +104,24 @@ public class TaskList {
      */
     public void deleteTaskAtPosition(int position) {
         taskList.remove(position - 1);
+    }
+
+    /**
+     * Detects if the task to be added is a duplicate of an existing task.
+     *
+     * @param taskList List of tasks to be checked against.
+     * @param description Description of task to be checked against that of the other tasks.
+     * @return True if the task is a duplicate of an existing task.
+     */
+    public static boolean isADuplicateTask(TaskList taskList, String description) {
+        int length = taskList.getSize();
+
+        for (int i = 1; i <= length; i++) {
+            String descToCheckAgainst = taskList.getTaskDescAtPosition(i).strip();
+            if (description.equals(descToCheckAgainst)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/tommy/task/Todo.java
+++ b/src/main/java/tommy/task/Todo.java
@@ -4,6 +4,7 @@ package tommy.task;
  * Represents the task of type Todo.
  */
 public class Todo extends Task {
+    private static final String symbol = "[T]";
 
     /**
      * Constructor for a Todo task with its status as default not done.
@@ -26,6 +27,6 @@ public class Todo extends Task {
     }
     @Override
     public String toString() {
-        return "[T]" + this.getStatusIcon() + this.description;
+        return symbol + this.getStatusIcon() + this.description;
     }
 }


### PR DESCRIPTION
Tasks can currently be duplicated within the task list, leading to potential confusion and inefficiencies. Having duplicate tasks in the task list can result in ambiguity.

Preventing duplicate tasks is more efficient as users do not have to check if they have previously input the task.

Let's introduce validation checks during task addition to ensure that duplicate tasks are not added to the list. Validating tasks before addition ensures a cleaner task list and enhance user experience. The proactive prevention of duplicates enhances the efficiency of task management for the user.